### PR TITLE
Fixed a bug that prevented babel from working on CCL.

### DIFF
--- a/src/enc-unicode.lisp
+++ b/src/enc-unicode.lisp
@@ -520,9 +520,9 @@ code points for each invalid byte."
   (check-type name keyword)
   (let ((swap-var (gensym "SWAP"))
         (code-point-counter-name
-          (format-symbol t '#:~a-code-point-counter (string name)))
-        (encoder-name (format-symbol t '#:~a-encoder (string name)))
-        (decoder-name (format-symbol t '#:~a-decoder (string name))))
+         (format-symbol t (string '#:~a-code-point-counter) (string name)))
+        (encoder-name (format-symbol t (string '#:~a-encoder) (string name)))
+        (decoder-name (format-symbol t (string '#:~a-decoder) (string name))))
     (labels ((make-bom-check-form (end start getter seq)
                (if (null endianness)
                  ``((,',swap-var
@@ -691,11 +691,9 @@ written in big-endian byte-order without a leading byte-order mark."
   (check-type endianness (or null (eql :le) (eql :be)))
   (let ((swap-var (gensym "SWAP"))
         (code-point-counter-name
-          (format-symbol t '#:~a-code-point-counter (string name)))
-        (encoder-name
-          (format-symbol t '#:~a-encoder (string name)))
-        (decoder-name
-          (format-symbol t '#:~a-decoder (string name))))
+         (format-symbol t (string '#:~a-code-point-counter) (string name)))
+        (encoder-name (format-symbol t (string '#:~a-encoder) (string name)))
+        (decoder-name (format-symbol t (string '#:~a-decoder) (string name))))
     (labels ((make-bom-check-form (end start getter src)
                (if (null endianness)
                  ``(when (not (zerop (- ,,end ,,start)))


### PR DESCRIPTION
The spec requires that FORMAT's control-string is a string, not a string designator. CCL is strict about this.
