### PR TITLE
Avoid initarg nameclash in IN-MEMORY-STREAM class

### DIFF
--- a/src/streams.lisp
+++ b/src/streams.lisp
@@ -88,7 +88,7 @@
     :initform :default :initarg :element-type :accessor element-type-of)
    (external-format
     :initform (ensure-external-format *default-character-encoding*)
-    :initarg :external-format :accessor external-format-of)
+    :initarg 'in-memory-external-format :accessor external-format-of)
    #+cmu
    (open-p
     :initform t :accessor in-memory-stream-open-p
@@ -159,7 +159,7 @@ contains the octes that were actually output."
                             (t (error "Illegal element-type ~S" element-type)))
                           :initial-size initial-buffer-size)
                  :element-type element-type
-                 :external-format (ensure-external-format external-format)))
+                 'in-memory-external-format (ensure-external-format external-format)))
 
 (defun make-in-memory-input-stream (data &key (element-type :default)
                                     external-format)
@@ -173,7 +173,7 @@ contains the octes that were actually output."
                  :vector data
                  :element-type element-type
                  :end (length data)
-                 :external-format (ensure-external-format external-format)))
+                 'in-memory-external-format (ensure-external-format external-format)))
 
 (defclass vector-stream ()
   ((vector

--- a/tests/streams.lisp
+++ b/tests/streams.lisp
@@ -43,3 +43,6 @@
     ;(print (file-position output))
     )
   #(195 169 195 161 197 145 197 177 195 186 197 177 12 107 195 182 114 116 101))
+
+(deftest make-in-memory-output-stream ;; just a smoke test
+  (make-in-memory-output-stream :element-type '(unsigned-byte 8)))


### PR DESCRIPTION
Some implementations of IN-MEMORY-OUTPUT-STREAM's ancestors, notably
the Allegro-specific implementation of
TRIVIAL-GRAY-STREAMS::FUNDAMENTAL-BINARY-OUTPUT-STREAM, don't expect
Babel-specific objects in :EXTERNAL-FORMAT initarg.

Unfortunately, this happened because the :EXTERNAL-FORMAT initarg was
also used by IN-MEMORY-STREAM, another ancestor to
IN-MEMORY-OUTPUT-STREAM. This fix ensures that the IN-MEMORY-STREAM
class takes an initarg that doesn't easily clash with other takes on
the meaning of :EXTERNAL-FORMAT.