### PR TITLE
Add aliases :gb2312 :gb18030 to :gbk encoding

### DIFF
--- a/src/enc-gbk.lisp
+++ b/src/enc-gbk.lisp
@@ -39,7 +39,8 @@
     "GBK is an extension of the GB2312 character set for simplified
 Chinese characters, used in the People's Republic of China."
   :max-units-per-char 4
-  :literal-char-code-limit #x80)
+  :literal-char-code-limit #x80
+  :aliases '(:gb2312 :gb18030))
 
 (define-condition invalid-gbk-byte (character-decoding-error)
   ()


### PR DESCRIPTION
GB 2312, GB 18030 and GBK 1.0 are compatible encodings, see
https://en.wikipedia.org/wiki/GB_18030